### PR TITLE
Print new EXT-X-DATERANGE collected in manifest (from reference app)

### DIFF
--- a/ReferenceApp/ReferenceApp.xcodeproj/project.pbxproj
+++ b/ReferenceApp/ReferenceApp.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		E8207CC826F17B8A00BF59AD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E8207CC726F17B8A00BF59AD /* Assets.xcassets */; };
 		E8207CCB26F17B8A00BF59AD /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E8207CC926F17B8A00BF59AD /* LaunchScreen.storyboard */; };
 		E8207CD526F17D1900BF59AD /* PFInterstitials in Frameworks */ = {isa = PBXBuildFile; productRef = E8207CD426F17D1900BF59AD /* PFInterstitials */; };
+		E820F72826F6A231000E2CD4 /* AVDateRangeMetadataGroup+hlsRepresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E820F72726F6A231000E2CD4 /* AVDateRangeMetadataGroup+hlsRepresentation.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -26,6 +27,7 @@
 		E8207CCA26F17B8A00BF59AD /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		E8207CCC26F17B8A00BF59AD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E8207CD226F17CFF00BF59AD /* PFInterstitials */ = {isa = PBXFileReference; lastKnownFileType = folder; name = PFInterstitials; path = ..; sourceTree = "<group>"; };
+		E820F72726F6A231000E2CD4 /* AVDateRangeMetadataGroup+hlsRepresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVDateRangeMetadataGroup+hlsRepresentation.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -61,13 +63,14 @@
 		E8207CBD26F17B8900BF59AD /* ReferenceApp */ = {
 			isa = PBXGroup;
 			children = (
+				E8207CCC26F17B8A00BF59AD /* Info.plist */,
 				E8207CBE26F17B8900BF59AD /* AppDelegate.swift */,
+				E820F72726F6A231000E2CD4 /* AVDateRangeMetadataGroup+hlsRepresentation.swift */,
 				E8207CC026F17B8900BF59AD /* SceneDelegate.swift */,
 				E8207CC226F17B8900BF59AD /* ViewController.swift */,
-				E8207CC426F17B8900BF59AD /* Main.storyboard */,
 				E8207CC726F17B8A00BF59AD /* Assets.xcassets */,
 				E8207CC926F17B8A00BF59AD /* LaunchScreen.storyboard */,
-				E8207CCC26F17B8A00BF59AD /* Info.plist */,
+				E8207CC426F17B8900BF59AD /* Main.storyboard */,
 			);
 			path = ReferenceApp;
 			sourceTree = "<group>";
@@ -152,6 +155,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E820F72826F6A231000E2CD4 /* AVDateRangeMetadataGroup+hlsRepresentation.swift in Sources */,
 				E8207CC326F17B8900BF59AD /* ViewController.swift in Sources */,
 				E8207CBF26F17B8900BF59AD /* AppDelegate.swift in Sources */,
 				E8207CC126F17B8900BF59AD /* SceneDelegate.swift in Sources */,

--- a/ReferenceApp/ReferenceApp.xcodeproj/xcshareddata/xcschemes/ReferenceApp.xcscheme
+++ b/ReferenceApp/ReferenceApp.xcodeproj/xcshareddata/xcschemes/ReferenceApp.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1250"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E8207CBA26F17B8900BF59AD"
+               BuildableName = "ReferenceApp.app"
+               BlueprintName = "ReferenceApp"
+               ReferencedContainer = "container:ReferenceApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E8207CBA26F17B8900BF59AD"
+            BuildableName = "ReferenceApp.app"
+            BlueprintName = "ReferenceApp"
+            ReferencedContainer = "container:ReferenceApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E8207CBA26F17B8900BF59AD"
+            BuildableName = "ReferenceApp.app"
+            BlueprintName = "ReferenceApp"
+            ReferencedContainer = "container:ReferenceApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ReferenceApp/ReferenceApp/AVDateRangeMetadataGroup+hlsRepresentation.swift
+++ b/ReferenceApp/ReferenceApp/AVDateRangeMetadataGroup+hlsRepresentation.swift
@@ -1,0 +1,87 @@
+//
+//  AVDateRangeMetadataGroup+hlsRepresentation.swift
+//  ReferenceApp
+//
+//  Created by Robert Galluccio on 18/09/2021.
+//
+
+import Foundation
+import AVFoundation
+
+private extension TimeInterval {
+    var pretty: String {
+        if self.rounded() == self {
+            return "\(Int(self))"
+        } else {
+            return "\(self)"
+        }
+    }
+}
+
+extension AVDateRangeMetadataGroup {
+    private enum DateRangeAttribute: String {
+        case CLASS
+        case DURATION
+        case PLANNED_DURATION = "PLANNED-DURATION"
+        case SCTE35_CMD = "SCTE35-CMD"
+        case SCTE35_OUT = "SCTE35-OUT"
+        case SCTE35_IN = "SCTE35-IN"
+        case END_ON_NEXT = "END-ON-NEXT"
+    }
+
+    var hlsRepresentation: String {
+        let iso8601DateFormatter = ISO8601DateFormatter()
+        var hlsTag = "#EXT-X-DATERANGE:START-DATE=\"\(iso8601DateFormatter.string(from: self.startDate))\""
+        if let id = self.uniqueID {
+            hlsTag += ",ID=\"\(id)\""
+        }
+        if let endDate = self.endDate {
+            hlsTag += ",END-DATE=\"\(iso8601DateFormatter.string(from: endDate))\""
+        }
+        items.forEach { item in
+            guard let key = item.key as? String, let attribute = DateRangeAttribute(rawValue: key) else {
+                if let custom = customAtrribute(from: item) {
+                    hlsTag += ",\(custom)"
+                }
+                return
+            }
+            switch attribute {
+            case .CLASS:
+                guard let value = item.stringValue else { return }
+                hlsTag += ",\(attribute.rawValue)=\"\(value)\""
+            case .DURATION:
+                guard let value = item.numberValue?.timeValue.seconds else { return }
+                hlsTag += ",\(attribute.rawValue)=\(value.pretty)"
+            case .PLANNED_DURATION:
+                guard let value = item.numberValue?.timeValue.seconds else { return }
+                hlsTag += ",\(attribute.rawValue)=\(value.pretty)"
+            case .SCTE35_CMD:
+                guard let value = item.dataValue?.map({ String(format: "%02hhX", $0) }).joined() else { return }
+                hlsTag += ",\(attribute.rawValue)=0x\(value)"
+            case .SCTE35_OUT:
+                guard let value = item.dataValue?.map({ String(format: "%02hhX", $0) }).joined() else { return }
+                hlsTag += ",\(attribute.rawValue)=0x\(value)"
+            case .SCTE35_IN:
+                guard let value = item.dataValue?.map({ String(format: "%02hhX", $0) }).joined() else { return }
+                hlsTag += ",\(attribute.rawValue)=0x\(value)"
+            case .END_ON_NEXT:
+                guard let value = item.stringValue else { return }
+                hlsTag += ",\(attribute.rawValue)=\(value)"
+            }
+        }
+        return hlsTag
+    }
+
+    private func customAtrribute(from item: AVMetadataItem) -> String? {
+        guard let key = item.key as? String, key.starts(with: "X-") else { return nil }
+        if let value = item.stringValue {
+            return "\(key)=\"\(value)\""
+        } else if let value = item.numberValue?.timeValue.seconds {
+            return "\(key)=\(value.pretty)"
+        } else if let value = item.dataValue?.map({ String(format: "%02hhX", $0) }).joined() {
+            return "\(key)=\(value)"
+        } else {
+            return nil
+        }
+    }
+}

--- a/ReferenceApp/ReferenceApp/ViewController.swift
+++ b/ReferenceApp/ReferenceApp/ViewController.swift
@@ -76,7 +76,22 @@ class ViewController: UIViewController {
     @IBAction func playLivePressed(_ sender: Any) {
         let player = AVPlayer(url: liveURL)
         let playerController = AVPlayerViewController()
+        let collector = AVPlayerItemMetadataCollector()
+        collector.setDelegate(self, queue: .main)
+        player.currentItem?.add(collector)
         playerController.player = player
         present(playerController, animated: true) { player.play() }
+    }
+}
+
+extension ViewController: AVPlayerItemMetadataCollectorPushDelegate {
+    func metadataCollector(
+        _ metadataCollector: AVPlayerItemMetadataCollector,
+        didCollect metadataGroups: [AVDateRangeMetadataGroup],
+        indexesOfNewGroups: IndexSet,
+        indexesOfModifiedGroups: IndexSet
+    ) {
+        let newGroups = indexesOfNewGroups.map { metadataGroups[$0] }
+        newGroups.forEach { print($0.hlsRepresentation) }
     }
 }


### PR DESCRIPTION
<!--
Please include the issue number that this PR addresses.

If the PR addresses no issue, then perhaps an issue should be created, or
perhaps it should be reconsidered whether the PR is necessary.

If the PR addresses multiple issues, then perhaps it should be broken down into
multiple PRs
-->
Fixes #3

## Description
<!--
Please provide a description of the PR. Some useful points may be:
  - How does the PR address the linked issue?
  - Why was this solution design chosen?
  - Are there any extra implications not mentioned in the issue that this PR
    introduces that may be worth calling out?
-->
The change is to integrate (in the reference app) adding an `AVPlayerItemMetadataCollector`, which sends notifications when new `EXT-X-DATERANGE` information is collected from the manifest. In order to know that new data has been collected, for now we're just printing to the console, and so an extension was added on `AVDateRangeMetadataGroup` to create a string representation of it that should represent closely the actual `EXT-X-DATERANGE` tag.

<!-- UNCOMMENT IF NEW FEATURE REQUIRES EXTRA INTEGRATION
## Integration Notes
-->
<!--
If the PR introduces some functionality that extends the public API, then this
should be documented here with an explanation of what the feature brings, and
notes on how a client would consume the new functionality.
-->

<!-- UNCOMMENT IF BREAKING CHANGES TO PUBLIC API ARE INTRODUCED
## Breaking Changes
-->
<!--
If the public API has been broken as a result of this change, then a clear
migration guide should be presented here, as well as an explanation for why the
breaking change was necessary.
-->
